### PR TITLE
prevent error if Collection.prototype[methodName] doesn't exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,13 +19,17 @@ import Promise from 'bluebird'
   'findOne',
   'update',
   'findAndModify',
+  '_findAndModify200',
+  '_findAndModify140',
   'save',
   'remove',
   'findAndRemove',
   'mapReduce',
   'group',
 ].forEach((methodName) => {
-  Collection.prototype[methodName] = Promise.promisify(Collection.prototype[methodName])
+  if (Collection.prototype[methodName]) {
+    Collection.prototype[methodName] = Promise.promisify(Collection.prototype[methodName])
+  }
 })
 
 const insert = Collection.prototype.insert


### PR DESCRIPTION
The way tingodb handles findAndModify means it doesn't exist on the prototype which was causing an error to be thrown during `Promise.promisify` call.  
https://github.com/Sanjo/tingodb/blob/master/lib/tcoll.js#L45

I think adding the `_findAndModify200` version to the methodName array will achieve the intended `promisify` result but not sure.  The primary goal of this patch is to prevent the error being thrown.